### PR TITLE
Fix: `selectionIndicatorColor` does not work for 6+ and 6s+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ os: osx
 osx_image: xcode7
 env:
     # List by `instruments -s devices`
-    - DESTINATION='platform=iOS Simulator,name=iPhone 5,OS=9.0'
-    - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=9.0'
-    - DESTINATION='platform=iOS Simulator,name=iPhone 6 Plus,OS=9.0'
-    - DESTINATION='platform=iOS Simulator,name=iPhone 6s,OS=9.0'
-    - DESTINATION='platform=iOS Simulator,name=iPhone 6s Plus,OS=9.0'
-    - A=1
-    - A=2
+    - NAME='iPhone 5s'
+    - NAME='iPhone 6' TRAVIS_MATRIX_LEADER=true
+    - NAME='iPhone 6 Plus'
+    - NAME='iPhone 6s'
+    - NAME='iPhone 6s Plus'
 install:
     - make bootstrap
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: objective-c
 os: osx
 osx_image: xcode7
+env:
+    # List by `instruments -s devices`
+    - DESTINATION='platform=iOS Simulator,name=iPhone 5,OS=9.0'
+    - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=9.0'
+    - DESTINATION='platform=iOS Simulator,name=iPhone 6 Plus,OS=9.0'
+    - DESTINATION='platform=iOS Simulator,name=iPhone 6s,OS=9.0'
+    - DESTINATION='platform=iOS Simulator,name=iPhone 6s Plus,OS=9.0'
 install:
     - make bootstrap
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
     - DESTINATION='platform=iOS Simulator,name=iPhone 6 Plus,OS=9.0'
     - DESTINATION='platform=iOS Simulator,name=iPhone 6s,OS=9.0'
     - DESTINATION='platform=iOS Simulator,name=iPhone 6s Plus,OS=9.0'
+    - A=1
+    - A=2
 install:
     - make bootstrap
 before_script:

--- a/CKPickerView/CKPickerView.swift
+++ b/CKPickerView/CKPickerView.swift
@@ -111,13 +111,13 @@ public class CKPickerView: UIPickerView {
     
     // MARK: - Private Implementations
     
-    private var titleLabels = [UILabel]()
+    var titleLabels = [UILabel]()
 
-    private var selectionIndicators = [UIView]()
+    var selectionIndicators = [UIView]()
 
-    private var selectionBackgroundView: UIView?
+    var selectionBackgroundView: UIView?
     
-    private func updateIndicatorsColor() {
+    private func updateIndicatorsColor() {        
         for view in selectionIndicators {
             view.backgroundColor = selectionIndicatorColor
         }

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ bootstrap:
 	brew install carthage
 
 deps:
-	carthage bootstrap --use-ssh --verbose | xcpretty
+	carthage bootstrap --verbose | xcpretty
 
 release:
 	zip -r -9 $(project).framework.zip Carthage/Build/iOS/*.framework

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 SHELL = /bin/bash -o pipefail
+DESTINATION ?= platform=iOS Simulator,name=iPhone 6,OS=9.0
+
 project = CKPickerView
 
 test: test-unit test-carthage test-cocoapods
 
 test-unit:
-	xcodebuild test -scheme $(project) -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO OBJROOT=$(PWD)/build SYMROOT=$(PWD)/build | xcpretty
+	xcodebuild test -scheme $(project) -destination "$(DESTINATION)" ONLY_ACTIVE_ARCH=NO OBJROOT=$(PWD)/build SYMROOT=$(PWD)/build | xcpretty
 
 test-carthage:
 	carthage build --verbose --no-skip-current | xcpretty

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,24 @@
 SHELL = /bin/bash -o pipefail
-DESTINATION ?= platform=iOS Simulator,name=iPhone 6,OS=9.0
-
 project = CKPickerView
 
+# Test Parameters
+PLATFORM ?= iOS Simulator
+NAME ?= iPhone 6
+OS ?= 9.0
+DESTINATION ?= platform=$(PLATFORM),name=$(NAME),OS=$(OS)
+
+
+ifeq ($(TRAVIS_CI),true)
+
+ifeq ($(TRAVIS_MATRIX_LEADER),true)
 test: test-unit test-carthage test-cocoapods
+else
+test: test-unit
+endif
+
+else
+test: test-unit test-carthage test-cocoapods
+endif
 
 test-unit:
 	xcodebuild test -scheme $(project) -destination "$(DESTINATION)" ONLY_ACTIVE_ARCH=NO OBJROOT=$(PWD)/build SYMROOT=$(PWD)/build | xcpretty

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ bootstrap:
 	brew install carthage
 
 deps:
-	carthage bootstrap --verbose | xcpretty
+	carthage bootstrap --use-ssh --verbose | xcpretty
 
 release:
 	zip -r -9 $(project).framework.zip Carthage/Build/iOS/*.framework

--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,8 @@ OS ?= 9.0
 DESTINATION ?= platform=$(PLATFORM),name=$(NAME),OS=$(OS)
 
 
-ifeq ($(TRAVIS_CI),true)
-
-ifeq ($(TRAVIS_MATRIX_LEADER),true)
-test: test-unit test-carthage test-cocoapods
-else
+ifeq ($(TRAVIS)$(TRAVIS_MATRIX_LEADER),true)
 test: test-unit
-endif
-
 else
 test: test-unit test-carthage test-cocoapods
 endif
@@ -31,15 +25,7 @@ test-cocoapods:
 
 bootstrap:
 	bundle install
-
-   # Detect Travis CI, see http://docs.travis-ci.com/user/environment-variables/
-ifeq ($(TRAVIS_CI),true)
-   # Cannot brew install carthage on Travis-CI
-	curl -OL https://github.com/Carthage/Carthage/releases/download/0.8/Carthage.pkg
-	sudo /usr/sbin/installer -pkg Carthage.pkg -target /
-else
 	brew install carthage
-endif
 
 deps:
 	carthage bootstrap --verbose | xcpretty

--- a/UnitTests/UnitTests.swift
+++ b/UnitTests/UnitTests.swift
@@ -13,6 +13,20 @@ import Nimble
 
 class UnitTests: XCTestCase {
     
+    class TestDataSource: NSObject, UIPickerViewDataSource {
+        
+        func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+            return 100
+        }
+        
+        func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
+            return 1
+        }
+    }
+    
+    var window = UIView(frame: CGRect(x: 0, y: 0, width: 600, height: 600))
+    var dataSource = TestDataSource()
+    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -56,6 +70,25 @@ class UnitTests: XCTestCase {
         expect(p.titles).to(equal(expectedTitles))
         expect(p.attributedTitles).to(equal(expectedAttributedTitles))
         expect(p.titleHeight).to(equal(kTitleHeight))
+    }
+    
+    func testSelectionIndicatorColor() {
+        var p: CKPickerView!
+        
+        // Given set selectionBackgroundColor
+        p = CKPickerView(frame: CGRect(x: 0, y: 0, width: 600, height: 600))
+        p.selectionBackgroundColor = UIColor.grayColor()
+        p.dataSource = dataSource
+        //        p.frame = CGRect(x: 0, y: 0, width: 600, height: 600)
+        
+        // When layout
+        
+//        UIApplication.sharedApplication().windows.first?.addSubview(p)
+        window.addSubview(p)
+        p.layoutSubviews()
+        
+        // It should detected selection indicators
+        expect(p.selectionIndicators.count).to(equal(2))
     }
     
     func testPerformanceExample() {

--- a/UnitTests/UnitTests.swift
+++ b/UnitTests/UnitTests.swift
@@ -73,22 +73,22 @@ class UnitTests: XCTestCase {
     }
     
     func testSelectionIndicatorColor() {
+        let expectedColor = UIColor.grayColor()
         var p: CKPickerView!
         
         // Given set selectionBackgroundColor
         p = CKPickerView(frame: CGRect(x: 0, y: 0, width: 600, height: 600))
-        p.selectionBackgroundColor = UIColor.grayColor()
+        p.selectionIndicatorColor = expectedColor
         p.dataSource = dataSource
-        //        p.frame = CGRect(x: 0, y: 0, width: 600, height: 600)
         
-        // When layout
-        
-//        UIApplication.sharedApplication().windows.first?.addSubview(p)
+        // When layout in window
         window.addSubview(p)
         p.layoutSubviews()
         
-        // It should detected selection indicators
+        // It should detect selection indicators
         expect(p.selectionIndicators.count).to(equal(2))
+        // It should display with expected color
+        expect(p.selectionIndicators.first?.backgroundColor).to(equal(expectedColor))
     }
     
     func testPerformanceExample() {


### PR DESCRIPTION
This PR fixed `selectionIndicatorColor` property does not work on iPhone 6+ and 6s+

Changes:
- Use new algorithm to detect `selectionIndicatorColor` instead of observing `didAddSubview` hook
- Enable Travis CI build matrix to test on more platforms
- Add tests to cover this bug
